### PR TITLE
fix(test): bypass Firefox terms-of-use popup stealing focus in headless CI

### DIFF
--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -47,7 +47,19 @@ module.exports = async (config) => {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['ChromeHeadless', 'FirefoxHeadless'],
+    browsers: ['ChromeHeadless', 'FirefoxHeadlessTest'],
+
+    customLaunchers: {
+      // Firefox's "terms of use" notification steals focus in headless mode, which
+      // prevents `Element.focus()` from firing focus events until it's dismissed.
+      // https://github.com/karma-runner/karma-firefox-launcher/issues/56
+      FirefoxHeadlessTest: {
+        base: 'FirefoxHeadless',
+        prefs: {
+          'termsofuse.bypassNotification': true,
+        },
+      },
+    },
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits


### PR DESCRIPTION
## Summary
- CI's Firefox test job was failing on 4 focus-dependent tests (`should focus on input`, `should switch the focus feature on/off`, `should toggle focus off when component unmounts`) while passing on local (older) Firefox installs.
- Root cause: recent Firefox versions show a "terms of use" notification in headless windows that steals focus, so `Element.focus()` no longer fires focus/focusin events until the popup is dismissed. See [karma-runner/karma-firefox-launcher#56](https://github.com/karma-runner/karma-firefox-launcher/issues/56).
- Fix: add a `FirefoxHeadlessTest` custom launcher in `karma.conf.cjs` (based on `FirefoxHeadless`) with the `termsofuse.bypassNotification: true` pref, and use it instead of the bare `FirefoxHeadless` launcher.

## Test plan
- [x] `npm test` passes locally (Chrome + Firefox)
- [x] `npm run lint` passes
- [ ] CI green on Firefox job (currently failing on master/PRs)